### PR TITLE
🌟 Upgrade dependencies and use latest Quarkus version (3.2.0.CR1) in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'application'
-	id "io.quarkus" version "2.15.3.Final"
+	id "io.quarkus" version "3.2.0.CR1"
 	id "com.diffplug.spotless" version "6.13.0"
 	id "org.kordamp.gradle.jandex" version "1.1.0"
 	id "net.ltgt.errorprone" version "3.0.1"
@@ -16,16 +16,14 @@ repositories {
 dependencies {
 	// Use JUnit Jupiter for testing.
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
-
 	implementation 'fr.inria.gforge.spoon:spoon-core:10.2.0'
 	implementation 'org.apache.maven:maven-embedder:3.8.7'
 	implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '6.4.0.202211300538-r'
-	// implementation 'io.quarkiverse.jgit:quarkus-jgit:2.3.0'
-	implementation group: 'io.quarkus.arc', name: 'arc', version: '2.15.3.Final'
-	implementation 'io.quarkiverse.githubapi:quarkus-github-api:1.313.1'
-	implementation(enforcedPlatform('io.quarkus:quarkus-bom:2.15.3.Final'))
-	implementation 'io.quarkiverse.githubaction:quarkus-github-action:0.9.2'
-	implementation 'io.quarkus:quarkus-junit5'
+	implementation group: 'io.quarkus.arc', name: 'arc', version: '3.2.0.CR1'
+	implementation 'io.quarkiverse.githubapi:quarkus-github-api:1.314.1'
+	implementation(enforcedPlatform('io.quarkus:quarkus-bom:3.2.0.CR1'))
+	implementation 'io.quarkiverse.githubaction:quarkus-github-action:2.0.0.Alpha1'
+	testImplementation 'io.quarkus:quarkus-junit5'
 	implementation("org.jboss.logmanager:log4j2-jboss-logmanager")
 
 	// nullaway

--- a/src/main/java/io/github/martinwitt/spoonrebuilder/impl/ReleaseServiceImpl.java
+++ b/src/main/java/io/github/martinwitt/spoonrebuilder/impl/ReleaseServiceImpl.java
@@ -1,6 +1,7 @@
 package io.github.martinwitt.spoonrebuilder.impl;
 
 import io.github.martinwitt.spoonrebuilder.api.ReleaseService;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -11,7 +12,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.StreamSupport;
-import javax.enterprise.context.ApplicationScoped;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/io/github/martinwitt/spoonrebuilder/impl/ResultCheckerImpl.java
+++ b/src/main/java/io/github/martinwitt/spoonrebuilder/impl/ResultCheckerImpl.java
@@ -2,10 +2,10 @@ package io.github.martinwitt.spoonrebuilder.impl;
 
 import io.github.martinwitt.spoonrebuilder.api.BuildFailException;
 import io.github.martinwitt.spoonrebuilder.api.ResultChecker;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
-import javax.enterprise.context.ApplicationScoped;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 


### PR DESCRIPTION
Updated Quarkus dependencies in build.gradle to version 3.2.0.CR1, and updated corresponding dependencies to match. Also cleaned up unused import statements in ReleaseServiceImpl.java and ResultCheckerImpl.java.